### PR TITLE
more precise tx parsing + remove circular reference

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -132,9 +132,8 @@ module.exports = (router) => {
         const tx = await NinaProcessor.provider.connection.getParsedTransaction(txId, 'confirmed')
         
         if (tx) {
-          const length = tx.transaction.message.instructions.length
-          const accounts = tx.transaction.message.instructions[length - 1].accounts
-          if (tx.meta.logMessages.some(log => log.includes('ReleasePurchase'))) {
+          const accounts = tx.transaction.message.instructions.find(i => i.programId.toBase58() === process.env.NINA_PROGRAM_ID)?.accounts
+          if (accounts && tx.meta.logMessages.some(log => log.includes('ReleasePurchase'))) {
             let releasePublicKey = accounts[2].toBase58()
             let accountPublicKey = accounts[0].toBase58()
             await NinaProcessor.addCollectorForRelease(releasePublicKey, accountPublicKey)


### PR DESCRIPTION
- using Orca for swaps means we can no longer rely on instruction placement in releasePurchase tx's - so we now look for the ix for the nina program
- circular dependence between processor and models/Release was resulting in failing addCollectorForRelease via api call to /accounts/:publicKey/collected (these were getting written in processExchangesAndTransactions in processor instead)
- only addCollectorForRelease if account is not already a collector for the release (prevents excessive error logs stating that the collector_release relation already exists