### PR TITLE
warm cache on images < 20 mins old

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nina-protocol/nina-db",
-  "version": "0.0.20",
+  "version": "0.0.22",
   "description": "",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/db/src/migrations/20230306215838_add_hub_updated_at.js
+++ b/db/src/migrations/20230306215838_add_hub_updated_at.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = function(knex) {
+  return knex.schema.table('hubs' , table => {
+    table.string('updatedAt');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = function(knex) {
+  
+};

--- a/db/src/models/Hub.js
+++ b/db/src/models/Hub.js
@@ -21,6 +21,7 @@ export default class Hub extends Model {
         data: { type: 'object' },
         dataUri: { type: 'string' },
         datetime: { type: 'string' },
+        updatedAt: { type: 'string' },
       },
     };
   }

--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -557,6 +557,10 @@ class NinaProcessor {
           if (release) {
             await Release.processRevenueShares(release, releaseRecord);
           }
+          // If release.createdAt is newer than 20 minutes, reset the image cache
+          if (Date.parse(releaseRecord.datetime) > (Date.now() - 1200000)) {
+            this.warmCache(releaseRecord.metadata.image);
+          }
         } catch (error) {
           console.log('error Release.processRevenueShares existingReleases: ', error)
         }
@@ -682,6 +686,7 @@ class NinaProcessor {
           data,
           dataUri: newHub.account.uri,
           datetime: new Date(newHub.account.datetime.toNumber() * 1000).toISOString(),
+          updatedAt: new Date(newHub.account.datetime.toNumber() * 1000).toISOString(),
           authorityId: authority.id,
         });
         console.log('Inserted Hub:', newHub.publicKey.toBase58());
@@ -867,10 +872,16 @@ class NinaProcessor {
       }
       await hub.$query().patch({
         data,
-        dataUri: hubAccount.account.uri
+        dataUri: hubAccount.account.uri,
+        updatedAt: new Date().toISOString(),
       });
     }
-  
+
+    // If hub.updatedAt is newer than 20 minutes, reset the image cache
+    if (Date.parse(hub.updatedAt) > (Date.now() - 1200000)) {
+      this.warmCache(hub.data.image);
+    }
+
     // Update Hub Releases
     const hubReleasesForHubOnChain = hubReleases.hubReleasesForHubOnChain;
     const hubReleasesForHubDb = hubReleases.hubReleasesForHubDb;
@@ -1001,6 +1012,25 @@ class NinaProcessor {
       } catch (err) {
         console.log(err);
       }
+    }
+  }
+
+  async warmCache(image) {
+    if (process.env.IMGIX_API_KEY) {
+      const purgeRequest = await axios.post('https://api.imgix.com/api/v1/purge', {
+        data: {
+          attributes: {
+            url: `${process.env.IMGIX_SOURCE_DOMAIN}/${encodeURIComponent(image)}`
+          },
+          type: 'purges'
+        }
+      }, {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${process.env.IMGIX_API_KEY}`
+        }
+      })
+      console.log('Warmed Cache On Image:', image)
     }
   }
 }

--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -32,6 +32,8 @@ import {
 const MAX_PARSED_TRANSACTIONS = 150
 const MAX_TRANSACTION_SIGNATURES = 1000
 
+const CACHE_RESET_TIME = 1200000 // 20 minutes
+
 const blacklist = [
   'BpZ5zoBehKfKUL2eSFd3SNLXmXHi4vtuV4U6WxJB3qvt',
   'FNZbs4pdxKiaCNPVgMiPQrpzSJzyfGrocxejs8uBWnf',
@@ -558,7 +560,7 @@ class NinaProcessor {
             await Release.processRevenueShares(release, releaseRecord);
           }
           // If release.createdAt is newer than 20 minutes, reset the image cache
-          if (Date.parse(releaseRecord.datetime) > (Date.now() - 1200000)) {
+          if (Date.parse(releaseRecord.datetime) > (Date.now() - CACHE_RESET_TIME)) {
             this.warmCache(releaseRecord.metadata.image);
           }
         } catch (error) {
@@ -878,7 +880,7 @@ class NinaProcessor {
     }
 
     // If hub.updatedAt is newer than 20 minutes, reset the image cache
-    if (Date.parse(hub.updatedAt) > (Date.now() - 1200000)) {
+    if (Date.parse(hub.updatedAt) > (Date.now() - CACHE_RESET_TIME)) {
       this.warmCache(hub.data.image);
     }
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@bonfida/spl-name-service": "^0.1.51",
     "@koa/cors": "^3.3.0",
     "@metaplex-foundation/js": "^0.18.1",
-    "@nina-protocol/nina-db": "./db",
+    "@nina-protocol/nina-db": "0.0.22",
     "@project-serum/anchor": "^0.25.0",
     "@redocly/cli": "^1.0.0-beta.108",
     "@solana/web3.js": "^1.73.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@bonfida/spl-name-service": "^0.1.51",
     "@koa/cors": "^3.3.0",
     "@metaplex-foundation/js": "^0.18.1",
-    "@nina-protocol/nina-db": "0.0.20",
+    "@nina-protocol/nina-db": "./db",
     "@project-serum/anchor": "^0.25.0",
     "@redocly/cli": "^1.0.0-beta.108",
     "@solana/web3.js": "^1.73.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1031,8 +1031,10 @@
     bn.js "^5.2.0"
     debug "^4.3.4"
 
-"@nina-protocol/nina-db@./db":
+"@nina-protocol/nina-db@0.0.22":
   version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.22.tgz#ba4273f5781a07a484b7a39905caed52c1ab6e49"
+  integrity sha512-08rncS9gUzdpBfcK7JbBzsKsOFpo/zqj08aLddnD4Gb6VgALG2BXJWCC7EOJ1iuyCnEf2eXzbltg4ZBd3hQGkA==
   dependencies:
     "@babel/plugin-proposal-object-rest-spread" "^7.20.7"
     "@babel/preset-es2015" "^7.0.0-beta.53"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1031,10 +1031,8 @@
     bn.js "^5.2.0"
     debug "^4.3.4"
 
-"@nina-protocol/nina-db@0.0.20":
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.20.tgz#442a8d2bbf97aebd3429a8df4b8ed295e419ae64"
-  integrity sha512-eUjf7svhteHzkqyUeNdcfk9H3H9aNqLCvyNFP64LFwxZ5axf8sUXtmbAW48Y/tjwDLP88b5hAl0/6eyWaNwFog==
+"@nina-protocol/nina-db@./db":
+  version "0.0.22"
   dependencies:
     "@babel/plugin-proposal-object-rest-spread" "^7.20.7"
     "@babel/preset-es2015" "^7.0.0-beta.53"


### PR DESCRIPTION
we have an issue where our cdn (IMGIX) caches images from arweave before they are accessible.  arweave doesnt have proper cache refresh header so the image cache with a broken response until we purge the image.  we have been doing this manually - this PR automates that.

- adds hubs.updatedAt column to track last time hub metadata has been updated
- if a release.datetime < 20 minutes -> release.metadata.image cache is purged
- if a hub.updatedAt < 20 minutes -> hub.data.image is purged

There are 2 new env vars:
- `IMGIX_API_KEY` 
- `IMGIX_SOURCE_DOMAIN`