### PR TITLE
Add --max-memory-restart flag to Node run scripts and ecosystem.config.js

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  apps: [{
+    name: 'nina-indexer',
+    script: 'indexer/index.js',
+    max_memory_restart: '2048M'
+  },
+  {
+    name: 'nina-api',
+    script: 'api/index.js',
+    max_memory_restart: '2048M'
+  }]
+};

--- a/run.sh
+++ b/run.sh
@@ -15,5 +15,5 @@ else
 fi
 
 cd /home/ec2-user/nina-indexer
-pm2 start yarn --name nina-indexer -- start:indexer
-pm2 start yarn --name nina-api -- start:api
+pm2 --max-memory-restart 2048M start yarn --name nina-indexer -- start:indexer
+pm2 --max-memory-restart 2048M start yarn --name nina-api -- start:api


### PR DESCRIPTION
@wildman should do the trick, tested with a very low memory threshold with heapstats enabled and will restart if threshold is exceeded (example output below):

216|nina-indexer  | Indexer Starting Up
216|nina-indexer  | Indexer Started - DB and Processor Initialized
216|nina-indexer  | Initial Sync starting
**PM2               | [PM2][WORKER] Process 216 restarted because it exceeds --max-memory-restart value (current_memory=67813376 max_memory_limit=52428800 [octets])**
PM2               | Process 216 in a stopped status, starting it
PM2               | Stopping app:nina-indexer id:216
PM2               | App [nina-indexer:216] exited with code [0] via signal [SIGINT]
PM2               | pid=14262 msg=process killed
PM2               | App [nina-indexer:216] starting in -fork mode-
PM2               | App [nina-indexer:216] online
216|nina-indexer  | yarn run v1.22.19
216|nina-indexer  | $ node indexer/index.js --heap-stats
216|nina-indexer  | Indexer Starting Up
216|nina-indexer  | Indexer Started - DB and Processor Initialized
216|nina-indexer  | Initial Sync starting
****PM2               | [PM2][WORKER] Process 216 restarted because it exceeds --max-memory-restart value** (current_memory=67940352 max_memory_limit=52428800 [octets])**
PM2               | Process 216 in a stopped status, starting it
PM2               | Stopping app:nina-indexer id:216
PM2               | App [nina-indexer:216] exited with code [0] via signal [SIGINT]
PM2               | pid=14299 msg=process killed
PM2               | App [nina-indexer:216] starting in -fork mode-
PM2               | App [nina-indexer:216] online
216|nina-indexer  | yarn run v1.22.19
216|nina-indexer  | $ node indexer/index.js --heap-stats
216|nina-indexer  | Indexer Starting Up
216|nina-indexer  | Indexer Started - DB and Processor Initialized
216|nina-indexer  | Initial Sync starting