### PR TITLE
ensure processCollectors is only run once at a time

### DIFF
--- a/indexer/index.js
+++ b/indexer/index.js
@@ -10,7 +10,7 @@ import { environmentIsSetup } from "../scripts/env_check.js";
 const arg = process.argv.slice()
 
 const startProcessing = async () => {
-  console.log('Indexer Starting Up')
+  console.log(`${new Date()} Indexer Starting Up`)
   await initDb(config)
   await NinaProcessor.init()
   console.log('Indexer Started - DB and Processor Initialized')
@@ -23,18 +23,18 @@ const startProcessing = async () => {
   console.log('Initial Sync complete')
 
   cron.schedule('* * * * *', async() => {
-    console.log('Cron job starting: Sync Hubs + Releases');
+    console.log(`${new Date()} Cron job starting: Sync Hubs + Releases`);
     if (arg[2]=="--heap-stats") {
       runHeapDiagnostics()
     }
     await NinaProcessor.runDbProcesses()
-    console.log('Cron job ended: Sync Hubs + Releases');
+    console.log(`${new Date()} Cron job ended: Sync Hubs + Releases`);
   });
   
   cron.schedule('0 * * * *', async() => {
-    console.log('Cron job starting: Sync Collectors');
+    console.log(`${new Date()} Cron job starting: Sync Collectors`);
     await NinaProcessor.processCollectors()
-    console.log('Cron job ended: Sync Collectors');
+    console.log(`${new Date()} Cron job ended: Sync Collectors`);
   })
 }
 

--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -53,6 +53,7 @@ class NinaProcessor {
     this.program = null;
     this.metaplex = null;
     this.latestSignature = null;
+    this.isProcessing = false;
   }
 
   async init() {
@@ -68,15 +69,22 @@ class NinaProcessor {
   }
 
   async runDbProcesses() {
-    try {
-      await this.processReleases();
-      await this.processPosts();
-      await this.processHubs();
-      await this.processSubscriptions();
-      await this.processVerifications();
-      await this.processExchangesAndTransactions();
-    } catch (error) {
-      console.warn(error)
+    if (!this.isProcessing) {
+      console.log(`running db processes`)
+      this.isProcessing = true;
+      try {
+        await this.processReleases();
+        await this.processPosts();
+        await this.processHubs();
+        await this.processSubscriptions();
+        await this.processVerifications();
+        await this.processExchangesAndTransactions();
+        this.isProcessing = false;
+      } catch (error) {
+        console.warn(error)
+      }
+    } else {
+      console.log(`db processes already running`)
     }
   }
 

--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -70,7 +70,7 @@ class NinaProcessor {
 
   async runDbProcesses() {
     if (!this.isProcessing) {
-      console.log(`running db processes`)
+      console.log(`${new Date()} Running DB processes`)
       this.isProcessing = true;
       try {
         await this.processReleases();
@@ -84,7 +84,7 @@ class NinaProcessor {
         console.warn(error)
       }
     } else {
-      console.log(`db processes already running`)
+      console.log(`${new Date()} DB processes already running`)
     }
   }
 


### PR DESCRIPTION
Looking at the prod indexers logs from `nina-indexer-out__2023-04-14_01-00-00.log` (the last logs presumably before the indexer app crashed on the 14th) we see a bunch of stacked Cron jobs:

![Screenshot 2023-04-19 at 12 16 44 PM](https://user-images.githubusercontent.com/2960410/233137538-05c4ad93-d2ec-4b7e-9b65-64780a735a60.png)

This PR ensures that only one `runDbProcesses()` loop will be run at a time.  

I have a guess that OOM errors are coming when a bunch of the loops are being run at the same time.  Potentially at the same time as a `processCollectors` loop which is much longer running and runs every hour on the hour for ~15 minutes at current data size.

The memory impact of this loop could be tests by simply called `runDbProcesses()` multiple times in the cron.scheduler in indexer/index.js on the main branch (i haven't tried this yet).

Regardless of whether this is the cause of the memory issues we are seeing it seems like a good idea to make sure that this process is only be run once at a time.

Also adds a time stamp to the cron jobs logs