### PR TITLE
Program updates

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1051,11 +1051,11 @@ export default (router) => {
         const accounts = transaction.transaction.message.instructions[length - 1].accounts
         if (accounts) {
           console.log('accounts.length', accounts.length)
-          if (accounts.length === 6) {
+          if (transaction.meta.logMessages.some(log => log.includes('ExchangeCancel'))) {
             console.log('found a cancel')
             const updatedAt = new Date(transaction.blockTime * 1000).toISOString()
             await Exchange.query().patch({cancelled: true, updatedAt}).findById(exchange.id)
-          } else if (accounts.length === 16) {
+          } else if (transaction.meta.logMessages.some(log => log.includes('ExchangeAccept'))) {
             console.log('found an accept')
             const completedByPublicKey = transaction.transaction.message.instructions[length - 1].accounts[0].toBase58()
             const updatedAt = new Date(transaction.blockTime * 1000).toISOString()

--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -415,7 +415,7 @@ class NinaProcessor {
                   }
 
                   if (accounts && !transactionObject.type) {
-                    if (accounts.length === 13) {
+                    if (accounts.length === 13 || tx.meta.logMessages.some(log => log.includes('ExchangeInit'))) {
                       try {
                         const mintPublicKey = accounts[1]
                         await this.provider.connection.getTokenSupply(mintPublicKey)
@@ -436,13 +436,13 @@ class NinaProcessor {
                       } catch (error) {
                         console.log('error not a token mint: ', txid, error)
                       }
-                    } else if (accounts.length === 6) {
+                    } else if (accounts.length === 6 || tx.meta.logMessages.some(log => log.includes('ExchangeCancel'))) {
                       exchangeCancels.push({
                         publicKey: accounts[2].toBase58(),
                         updatedAt: datetime
                       })
                       console.log('found an exchange cancel', accounts[2].toBase58())
-                    } else if (accounts.length === 16) {
+                    } else if (accounts.length === 16 || tx.meta.logMessages.some(log => log.includes('ExchangeAccept'))) {
                       completedExchanges.push({
                         publicKey: accounts[2].toBase58(),
                         legacyExchangePublicKey: accounts[7].toBase58(),
@@ -450,7 +450,7 @@ class NinaProcessor {
                         updatedAt: datetime
                       })
                       transactionObject.type = 'ExchangeAccept'
-                      releasePublicKey = accounts[12].toBase58()
+                      releasePublicKey = accounts[10].toBase58()
                       accountPublicKey = accounts[0].toBase58()
                       console.log('found an exchange completed', accounts[2].toBase58())
                     }

--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -371,15 +371,29 @@ class NinaProcessor {
                   toHubPublicKey = accounts[3].toBase58()
                 } else if (tx.meta.logMessages.some(log => log.includes('SubscriptionSubscribeAccount'))) {
                   transactionObject.type = 'SubscriptionSubscribeAccount'
-                  accountPublicKey = accounts[0].toBase58()
-                  toAccountPublicKey = accounts[2].toBase58()
+                  // By adding a PAYER account to the subscription to accomodate delegated subscriptions, 
+                  // we increase the accounts size from 4 to 5 and need to do the below to remain backwards compatible
+                  // with subscriptions created before nina v0.2.14
+                  if (accounts.length === 4) {
+                    accountPublicKey = accounts[0].toBase58()
+                    toHubPublicKey = accounts[2].toBase58()
+                  } else {
+                    accountPublicKey = accounts[1].toBase58()
+                    toHubPublicKey = accounts[3].toBase58()
+    
+                  }
                 } else if (tx.meta.logMessages.some(log => log.includes('SubscriptionSubscribeHub'))) {
                   transactionObject.type = 'SubscriptionSubscribeHub'
-                  accountPublicKey = accounts[0].toBase58()
-                  toHubPublicKey = accounts[2].toBase58()
-                } else if (tx.meta.logMessages.some(log => log.includes('SubscriptionUnsubscribeDelegated'))) {
-                  transactionObject.type = 'SubscriptionUnsubscribeDelegated'
-                  accountPublicKey = accounts[1].toBase58()
+                  // By adding a PAYER account to the subscription to accomodate delegated subscriptions, 
+                  // we increase the accounts size from 4 to 5 and need to do the below to remain backwards compatible
+                  // with subscriptions created before nina v0.2.14
+                  if (accounts.length === 4) {
+                    accountPublicKey = accounts[0].toBase58()
+                    toHubPublicKey = accounts[2].toBase58()
+                  } else {
+                    accountPublicKey = accounts[1].toBase58()
+                    toHubPublicKey = accounts[3].toBase58()
+                  }
                 } else if (tx.meta.logMessages.some(log => log.includes('SubscriptionUnsubscribe'))) {
                   transactionObject.type = 'SubscriptionUnsubscribe'
                   accountPublicKey = accounts[1].toBase58()


### PR DESCRIPTION
in the new program updates we remove secondary fees to the nina vault

we also removed these as account inputs to the exchange_accept instruction - as such the accounts array is 2 accounts smaller - for the `processor` we need to take this into account so that legacy exchange_accept instructions can still be properly parsed.  for `api` we can use the new model that simply looks at the logs for the instruction name.

the new program also adds a `payer` account to `subscription_subscribe_*` calls which increases the account size by 1 - and we have to check accounts size accordingly to properly parse legacy calls.