### PR TITLE
add hub updatedAt to callback api call

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -729,6 +729,7 @@ export default (router) => {
         await  Hub.query().patch({
           data: data.data,
           dataUri: uri,
+          updatedAt: new Date().toISOString(),
         }).findById(hub.id);
       }
       ctx.body = {


### PR DESCRIPTION
noticed that hub images were getting broken on update - turned out to be a two fold problem - devnets selfhosted db didnt have the migration that added hub updatedAt, so i pointed devnet server at the api-public-dev rds db.

then added hubUpdated to the patch in the api callback below