### PR TITLE
typo fix

### DIFF
--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -376,10 +376,10 @@ class NinaProcessor {
                   // with subscriptions created before nina v0.2.14
                   if (accounts.length === 4) {
                     accountPublicKey = accounts[0].toBase58()
-                    toHubPublicKey = accounts[2].toBase58()
+                    toAccountPublicKey = accounts[2].toBase58()
                   } else {
                     accountPublicKey = accounts[1].toBase58()
-                    toHubPublicKey = accounts[3].toBase58()
+                    toAccountPublicKey = accounts[3].toBase58()
     
                   }
                 } else if (tx.meta.logMessages.some(log => log.includes('SubscriptionSubscribeHub'))) {


### PR DESCRIPTION
noticed some broken items in the feed - turns out there was a typo in processing subscription subscribe accounts

<img width="536" alt="Screenshot 2023-05-10 at 5 43 24 PM" src="https://github.com/nina-protocol/nina-indexer/assets/2960410/74f90244-5171-4f18-8ce8-e1eb3f6a980a">

i believe that this will probably affect some subscriptions from the last day or so - after we merge this we should probably think of a way to fix the old data that has hubs saved in place of account - probably a script that checks all `SubscriptionSubscribeAccount` type transactions and makes sure that they have toAccounts and if not fixes them