### PR TITLE
save larger soundcloud avatar

### DIFF
--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -174,7 +174,7 @@ class NinaProcessor {
               if (profile) {
                 await Verification.query().patch({
                   displayName: profile.username,
-                  image: profile.avatar_url,
+                  image: profile.avatar_url.replace('-large.jpg', '-t500x500.jpg'),
                   active: true,
                 }).where({ publicKey: nameRegistry.publicKey });
               } else {
@@ -234,7 +234,7 @@ class NinaProcessor {
         const soundcloudProfile = await getSoundcloudProfile(name.soundcloudHandle);
         if (soundcloudProfile) {  
           verification.displayName = soundcloudProfile.username
-          verification.image = soundcloudProfile.avatar_url
+          verification.image = soundcloudProfile.avatar_url.replace('-large.jpg', '-t500x500.jpg')
           if (soundcloudProfile.description) {
             // verification.description = soundcloudProfile.description
           }


### PR DESCRIPTION
while working on moving the feed out of the drawer and into it's own page I noticed that they soundcloud avatars we were saving into the db were `large` sized which is actually small:

![image](https://github.com/nina-protocol/nina-indexer/assets/2960410/4dcad4f4-ddd3-4969-86c0-02f6ecc9717a)

we want `t500x500` sized:

![image](https://github.com/nina-protocol/nina-indexer/assets/2960410/87ca7ad1-4d69-404e-962d-68aab8212a24)
 

this pr saves the big ones.  ive already run a script to make convert the `large` size to `t500x500`