### PR TITLE
Cc collect override

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -200,7 +200,7 @@ export default (router) => {
               }, {
                 memcmp: {
                   offset: 0,
-                  bytes: release.account.releaseMint.toBase58()
+                  bytes: release.releaseMint.toBase58()
                 }
               }
             ]


### PR DESCRIPTION
adds a query param `releasePublicKey` to `/accounts/:publicKey/collected` that will check if user has a balance of token and add them as a collector if they do.

this handles coinflow cc integration where we are not able to get a `txid` for successful transaction.