### PR TITLE
set proper commitment level in api /accounts/:publicKey/collected

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -197,7 +197,7 @@ export default (router) => {
         if (release) {
           let tokenAccountsForRelease = await NinaProcessor.tokenIndexProvider.connection.getParsedProgramAccounts(
             new anchor.web3.PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"), {
-            commitment: NinaProcessor.provider.connection.commitment,
+            commitment: 'confirmed',
             filters: [{
                 dataSize: 165
               }, {
@@ -210,7 +210,7 @@ export default (router) => {
           })
           const tokenAccounts = tokenAccountsForRelease.filter(ta => ta.account.data.parsed.info.owner === ctx.params.publicKey)
           if (tokenAccounts.length > 0) {
-            let response = await NinaProcessor.tokenIndexProvider.connection.getTokenAccountBalance(tokenAccounts[0].pubkey, NinaProcessor.provider.connection.commitment)
+            let response = await NinaProcessor.tokenIndexProvider.connection.getTokenAccountBalance(tokenAccounts[0].pubkey, 'confirmed')
             if (response.value.uiAmount > 0) {
               await NinaProcessor.addCollectorForRelease(releasePublicKey, ctx.params.publicKey)
             }


### PR DESCRIPTION
NinaProcessor.provider.connection.commitment was `undefined` which would cause the new `releasePublicKey` checks on this endpoint too have the default commitment which is too strict for our needs here.