### PR TITLE
Filter by query + sort by column

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -173,7 +173,8 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/collected', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const { txId, releasePublicKey } = ctx.query;
       if (txId) {
@@ -219,7 +220,7 @@ export default (router) => {
       }
       
       const collected = await account.$relatedQuery('collected')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let release of collected.results) {
         release.collectedDate = await getCollectedDate(release, account)
@@ -238,10 +239,11 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/hubs', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const hubs = await account.$relatedQuery('hubs')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let hub of hubs.results) {
         await hub.format();
@@ -258,10 +260,11 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/posts', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const posts = await account.$relatedQuery('posts')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let post of posts.results) {
         await post.format();
@@ -278,10 +281,11 @@ export default (router) => {
   
   router.get('/accounts/:publicKey/published', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       let published = await account.$relatedQuery('published')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       const publishedVisible = await getVisibleReleases(published.results)
 
@@ -297,13 +301,13 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/exchanges', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
-      console.log('limit', limit)
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='createdAt' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const exchanges = await Exchange.query()
         .where('completedById', account.id)
         .orWhere('initializerId', account.id)
-        .orderBy('createdAt', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
 
       for await (let exchange of exchanges.results) {
@@ -321,10 +325,11 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/revenueShares', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       let revenueShares = await account.$relatedQuery('revenueShares')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
 
       const revenueSharesVisible = await getVisibleReleases(revenueShares.results)
@@ -341,12 +346,13 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/subscriptions', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const subscriptions = await Subscription.query()
         .where('from', account.publicKey)
         .orWhere('to', account.publicKey)
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       
       for await (let subscription of subscriptions.results) {
@@ -592,10 +598,11 @@ export default (router) => {
   
   router.get('/releases', async (ctx) => {
     try {
-      const { offset=0, limit=20, sort='desc' } = ctx.query;
+      const { offset=0, limit=20, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const releases = await Release
         .query()
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
 
 
@@ -637,10 +644,11 @@ export default (router) => {
 
   router.get('/releases/:publicKey/exchanges', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='createdAt' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const release = await Release.query().findOne({publicKey: ctx.params.publicKey})
       const exchanges = await release.$relatedQuery('exchanges')
-        .orderBy('createdAt', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
 
       for await (let exchange of exchanges.results) {
@@ -692,10 +700,11 @@ export default (router) => {
 
   router.get('/releases/:publicKey/hubs', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const release = await Release.query().findOne({publicKey: ctx.params.publicKey})
       const hubs = await release.$relatedQuery('hubs')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
 
       for await (let hub of hubs.results) {
@@ -738,11 +747,12 @@ export default (router) => {
 
   router.get('/hubs', async (ctx) => {
     try {
-      const { offset=0, limit=20, sort='desc'} = ctx.query;
+      const { offset=0, limit=20, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const hubs = await Hub.query()
         .whereExists(Hub.relatedQuery('releases'))
         .orWhereExists(Hub.relatedQuery('posts'))
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
 
       for await (let hub of hubs.results) {
@@ -877,10 +887,11 @@ export default (router) => {
 
   router.get('/hubs/:publicKeyOrHandle/releases', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const hub = await hubForPublicKeyOrHandle(ctx)
       let releases = await hub.$relatedQuery('releases')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       const releasesVisible = await getVisibleReleases(releases.results)
       ctx.body = { 
@@ -896,10 +907,11 @@ export default (router) => {
 
   router.get('/hubs/:publicKeyOrHandle/posts', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const hub = await hubForPublicKeyOrHandle(ctx)
       const posts = await hub.$relatedQuery('posts')
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let post of posts.results) {
         await post.format();
@@ -1072,12 +1084,13 @@ export default (router) => {
 
   router.get('/hubs/:publicKeyOrHandle/subscriptions', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc' } = ctx.query;
+      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const hub = await hubForPublicKeyOrHandle(ctx)
       const subscriptions = await Subscription.query()
-        .where('subscriptions.to', hub.publicKey)
-        .where('subscriptions.subscriptionType', 'hub')
-        .orderBy('subscriptions.datetime', sort)
+        .where('to', hub.publicKey)
+        .where('subscriptionType', 'hub')
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let subscription of subscriptions.results) {
         await subscription.format();
@@ -1096,10 +1109,10 @@ export default (router) => {
 
   router.get('/posts', async (ctx) => {
     try {
-      const { offset=0, limit=20, sort='desc'} = ctx.query;
+      const { offset=0, limit=20, sort='desc', column='datetime'} = ctx.query;
       const posts = await Post
         .query()
-        .orderBy('datetime', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let post of posts.results) {
         await post.format();
@@ -1142,10 +1155,11 @@ export default (router) => {
   
   router.get('/exchanges', async (ctx) => {
     try {
-      const { offset=0, limit=20, sort='desc'} = ctx.query;
+      const { offset=0, limit=20, sort='desc', column='createdAt' } = ctx.query;
+      column = formatColumnForJsonFields(column);
       const exchanges = await Exchange
         .query()
-        .orderBy('createdAt', sort)
+        .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let exchange of exchanges.results) {
         await exchange.format();
@@ -1571,4 +1585,11 @@ const hubForPublicKeyOrHandle = async (ctx) => {
     hub = await Hub.query().findOne({handle: ctx.params.publicKeyOrHandle})
   }
   return hub
+}
+
+const formatColumnForJsonFields = (column) => {
+  if (column.includes(':')) {
+    column = ref(column).castText()
+  }
+  return column
 }

--- a/api/api.js
+++ b/api/api.js
@@ -173,7 +173,7 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/collected', async (ctx) => {
     try {
-      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const { txId, releasePublicKey } = ctx.query;
@@ -221,6 +221,7 @@ export default (router) => {
       
       const collected = await account.$relatedQuery('collected')
         .orderBy(column, sort)
+        .where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let release of collected.results) {
         release.collectedDate = await getCollectedDate(release, account)
@@ -239,11 +240,12 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/hubs', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const hubs = await account.$relatedQuery('hubs')
         .orderBy(column, sort)
+        .where(ref('data:displayName').castText(), 'ilike', `%${query}%`)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let hub of hubs.results) {
         await hub.format();
@@ -260,12 +262,14 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/posts', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const posts = await account.$relatedQuery('posts')
         .orderBy(column, sort)
+        .where(ref('data:title').castText(), 'ilike', `%${query}%`)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
+        
       for await (let post of posts.results) {
         await post.format();
       }
@@ -281,11 +285,12 @@ export default (router) => {
   
   router.get('/accounts/:publicKey/published', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       let published = await account.$relatedQuery('published')
         .orderBy(column, sort)
+        .where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       const publishedVisible = await getVisibleReleases(published.results)
 
@@ -301,7 +306,7 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/exchanges', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='createdAt' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='createdAt' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const exchanges = await Exchange.query()
@@ -325,11 +330,12 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/revenueShares', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       let revenueShares = await account.$relatedQuery('revenueShares')
         .orderBy(column, sort)
+        .where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
 
       const revenueSharesVisible = await getVisibleReleases(revenueShares.results)
@@ -346,7 +352,7 @@ export default (router) => {
 
   router.get('/accounts/:publicKey/subscriptions', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const account = await Account.findOrCreate(ctx.params.publicKey);
       const subscriptions = await Subscription.query()
@@ -598,7 +604,7 @@ export default (router) => {
   
   router.get('/releases', async (ctx) => {
     try {
-      const { offset=0, limit=20, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=20, sort='desc', column='datetime' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const releases = await Release
         .query()
@@ -644,7 +650,7 @@ export default (router) => {
 
   router.get('/releases/:publicKey/exchanges', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='createdAt' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='createdAt' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const release = await Release.query().findOne({publicKey: ctx.params.publicKey})
       const exchanges = await release.$relatedQuery('exchanges')
@@ -700,7 +706,7 @@ export default (router) => {
 
   router.get('/releases/:publicKey/hubs', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const release = await Release.query().findOne({publicKey: ctx.params.publicKey})
       const hubs = await release.$relatedQuery('hubs')
@@ -747,7 +753,7 @@ export default (router) => {
 
   router.get('/hubs', async (ctx) => {
     try {
-      const { offset=0, limit=20, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=20, sort='desc', column='datetime' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const hubs = await Hub.query()
         .whereExists(Hub.relatedQuery('releases'))
@@ -887,11 +893,12 @@ export default (router) => {
 
   router.get('/hubs/:publicKeyOrHandle/releases', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const hub = await hubForPublicKeyOrHandle(ctx)
       let releases = await hub.$relatedQuery('releases')
         .orderBy(column, sort)
+        .where('metadata:name', 'ilike', `%${query}%`)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       const releasesVisible = await getVisibleReleases(releases.results)
       ctx.body = { 
@@ -907,11 +914,12 @@ export default (router) => {
 
   router.get('/hubs/:publicKeyOrHandle/posts', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const hub = await hubForPublicKeyOrHandle(ctx)
       const posts = await hub.$relatedQuery('posts')
         .orderBy(column, sort)
+        .where('data:title', 'ilike', `%${query}%`)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
       for await (let post of posts.results) {
         await post.format();
@@ -1084,7 +1092,7 @@ export default (router) => {
 
   router.get('/hubs/:publicKeyOrHandle/subscriptions', async (ctx) => {
     try {
-      const { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
+      let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const hub = await hubForPublicKeyOrHandle(ctx)
       const subscriptions = await Subscription.query()
@@ -1155,7 +1163,7 @@ export default (router) => {
   
   router.get('/exchanges', async (ctx) => {
     try {
-      const { offset=0, limit=20, sort='desc', column='createdAt' } = ctx.query;
+      let { offset=0, limit=20, sort='desc', column='createdAt' } = ctx.query;
       column = formatColumnForJsonFields(column);
       const exchanges = await Exchange
         .query()


### PR DESCRIPTION
add filterBy query and sortBy column to relevant api endpoints for v2 hub + profile pages

expected query params for sort are now:
 ```
offset: number
limit: number
sort: 'desc' | 'asc'
column: string  // see notes below for expected values
query: string // eg '400 floor'
```

column should be the name of the db column to sort by.  this will be the values on the object returned by the db.

for ordering by properties of json objects like `release.metadata`, `hub.data`, `post.data` you need to use a `:` instead of a `.` to denote entrance into the json object.

some examples:
- to sort releases by date published use `column: 'datetime'`
- to sort releases by title use `column: 'metadata:name'`
- to sort hubs by name use `column: 'data:displayName`
- to sort posts by title use `column: 'data:title'`

closes #248 and #249 