### PR TITLE
All

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -177,7 +177,6 @@ export default (router) => {
       column = formatColumnForJsonFields(column);
 
       const account = await Account.findOrCreate(ctx.params.publicKey);
-
       const collected = await account.$relatedQuery('collected')
         .orderBy(column, sort)
         .where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
@@ -202,7 +201,6 @@ export default (router) => {
         await post.format();
         post.type = 'post'
       }
-
 
       let published = await account.$relatedQuery('published')
         .orderBy(column, sort)


### PR DESCRIPTION
adds endpoints:
- `GET  /accounts/:publicKey/all`
-- returns collected releases, published releases, hubs, and posts for a user
- `GET /hubs/:publicKeyOrHandle/all`
-- return releases published through, releases reposted to, and posts for a hub

closes #251 


admittedly not the most efficient way - should be doing raw sql queries or have a migration with a common parent class that hub/release/post all inherit to avoid always fetching all records.  that can be something for later - for sake of expediency this will do for now