### PR TITLE
relate release to hub

### DIFF
--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -1313,6 +1313,9 @@ class NinaProcessor {
         if (hubReleasesForHubDb.includes(hubRelease.account.release.toBase58())) {
           const hubContent = hubContents.filter(x => x.account.child.toBase58() === hubRelease.publicKey.toBase58())
           const release = await Release.query().findOne({publicKey: hubRelease.account.release.toBase58()});
+          if (!release.hubId && hub.authorityId === release.publisherId) {
+            await release.$query().patch({hubId: hub.id});
+          }
           if (release) {
             let visible = false;
             hubContent.forEach(hc => {


### PR DESCRIPTION
users frequently report following situation:

1. they publish a release before they make a hub
2. they make a hub
3. they add the release in 1 to the hub

Expected result: release should have the blue hub text
Actual result: release does not have blue hub text

here, if release doesnt have a published through hub but hub.authority === release.publisher add `release.hubId === hub.id` to meet users expected behavior