### PR TITLE
Sanitize tags

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nina-protocol/nina-db",
-  "version": "0.0.67",
+  "version": "0.0.70",
   "description": "",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/db/package.json
+++ b/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nina-protocol/nina-db",
-  "version": "0.0.70",
+  "version": "0.0.72",
   "description": "",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/db/src/migrations/20240304143626_fix_tags_content.js
+++ b/db/src/migrations/20240304143626_fix_tags_content.js
@@ -4,6 +4,7 @@
  */
 export const up = function (knex) {
   return Promise.all([
+      knex.schema.dropTable('tags_content'),
       knex.schema.createTable('tags_releases', table => {
           table.primary(['tagId', 'releaseId']);
           table.integer('releaseId')
@@ -18,8 +19,6 @@ export const up = function (knex) {
               .inTable('tags')
               .onDelete('CASCADE')
               .index();
-          table.timestamp('created_at').defaultTo(knex.fn.now());
-          table.timestamp('updated_at').defaultTo(knex.fn.now());
       }),
   ]);
 };

--- a/db/src/models/Tag.js
+++ b/db/src/models/Tag.js
@@ -12,10 +12,13 @@ export default class Tag extends Model {
     },
   }
 
+  static sanitizeValue = (value) => value.toLowerCase().replace('#', '').replace(',', '');
+
   static findOrCreate = async (value) => {
-    let tag = await Tag.query().where('value', value).first();
+    const sanitizedValue = this.sanitizeValue(value);
+    let tag = await Tag.query().where('value', sanitizedValue).first();
     if (!tag) {
-      tag = await Tag.query().insert({ value });
+      tag = await Tag.query().insert({ value: sanitizedValue });
     }
     return tag;
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@bonfida/spl-name-service": "^0.1.51",
     "@koa/cors": "^3.3.0",
     "@metaplex-foundation/js": "^0.18.1",
-    "@nina-protocol/nina-db": "0.0.67",
+    "@nina-protocol/nina-db": "0.0.72",
     "@project-serum/anchor": "^0.25.0",
     "@redocly/cli": "^1.0.0-beta.108",
     "@solana/web3.js": "^1.73.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     bn.js "^5.2.0"
     debug "^4.3.4"
 
-"@nina-protocol/nina-db@0.0.67":
-  version "0.0.67"
-  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.67.tgz#c9b23b8954dac9ca803f0f63ffdfbe2646e87337"
-  integrity sha512-MAwafO/N5/IwVkTyKfOdNzWp9CI3wh554UZP+/QIGoOKBJOR88eW3N1smokJzG1TVVtcRbPVNvdnPhl+Odw17Q==
+"@nina-protocol/nina-db@0.0.72":
+  version "0.0.72"
+  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.72.tgz#f360783387c593202bdf0b2aaf7ee8e71a0f1ca0"
+  integrity sha512-HPe2faILQeqPbFwUu1U+UTpDi+1wNIH4SvXmTTo/4pzXfHH5KGlifj5F6jlLisRTO2mCzhaYobcTNVbtDLt+7Q==
   dependencies:
     "@babel/plugin-proposal-object-rest-spread" "^7.20.7"
     "@babel/preset-es2015" "^7.0.0-beta.53"


### PR DESCRIPTION
when ian implemented frontend for tags i realized that next caches pages case insensitively, which caused a problem for our tags (probably made sense any way to sanitize them).

In doing this i had a bunch of local migration issues that i then realized was bc the migration in the nina-db build for tags was different than the one in main - i must not have rebuilt the app before publishing which ever version last used.  so i have swapped out the migration from the build with the one in main.

Below is the current `knex_migrations` table on `api-public`
![Screenshot 2024-03-07 at 4 08 55 PM](https://github.com/nina-protocol/nina-indexer/assets/2960410/da928cac-9d85-4675-9646-fe0b36b5f963)
