### PR TITLE
return if tx already exists

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -999,7 +999,7 @@ export default (router) => {
               await NinaProcessor.processTransaction(tx, txid, blocktime, accounts)
             }  
           } catch (error) {
-            console.log('tx already in db')
+            console.log(`tx already in db: ${txid}`)
           }
         }
         release = await Release.findOrCreate(ctx.params.publicKeyOrSlug)

--- a/api/api.js
+++ b/api/api.js
@@ -991,11 +991,15 @@ export default (router) => {
           maxSupportedTransactionVersion: 0
         })
         if (tx) {
-          const ninaInstruction = tx.transaction.message.instructions.find(i => i.programId.toBase58() === process.env.NINA_PROGRAM_ID)
-          const accounts = ninaInstruction?.accounts
-          const blocktime = tx.blockTime
-          if (txid && accounts && blocktime) {
-            await NinaProcessor.processTransaction(tx, txid, blocktime, accounts)
+          try {
+            const ninaInstruction = tx.transaction.message.instructions.find(i => i.programId.toBase58() === process.env.NINA_PROGRAM_ID)
+            const accounts = ninaInstruction?.accounts
+            const blocktime = tx.blockTime
+            if (txid && accounts && blocktime) {
+              await NinaProcessor.processTransaction(tx, txid, blocktime, accounts)
+            }  
+          } catch (error) {
+            console.log('tx already in db')
           }
         }
         release = await Release.findOrCreate(ctx.params.publicKeyOrSlug)


### PR DESCRIPTION
believe we ran into a race condition this morning where the tx was processed before the release callback returned

if tx already existed an error would get thrown and release would not be returned as expected

now it fails gracefully