### PR TITLE
fix /hubs/:handle/releases length

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1469,7 +1469,7 @@ export default (router) => {
 
       ctx.body = { 
         releases: releasesVisible,
-        total: releasesVisible.length,
+        total: releases.length,
         publicKey: hub.publicKey,
         query,
       };


### PR DESCRIPTION
technically this will have an incorrect length for hubs with any `hubRelease.visible = false` releases - it will over count.  this is a rare-ish scenario that shouldn't break the frontend too seriously.  the forthcoming hide release functionality should fix this as well bc visibility bc easier to query directly on the release.

closes #584 
