### PR TITLE
GET /search/all

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -2084,6 +2084,72 @@ export default (router) => {
     }
   });
 
+  router.get('/search/all', async (ctx) => {
+    try {
+      let { offset=0, limit=3, sort='desc', query='' } = ctx.query;
+
+      const accounts = await Account.query()
+        .where('displayName', 'ilike', `%${query}%`)
+        .orWhere('handle', 'ilike', `%${query}%`)
+        .orderBy('displayName', sort)
+        .range(Number(offset), Number(offset) + Number(limit) - 1);
+      
+      for await (let account of accounts.results) {
+        account.type = 'account'
+        await account.format();
+      }
+  
+      const releases = await Release.query()
+        .where(ref('metadata:properties.artist').castText(), 'ilike', `%${query}%`)
+        .orWhere(ref('metadata:properties.title').castText(), 'ilike', `%${query}%`)
+        .orWhere(ref('metadata:properties.tags').castText(), 'ilike', `%${query}%`)
+        .orWhere(ref('metadata:symbol').castText(), 'ilike', `%${query}%`)
+        .orWhereIn('hubId', getPublishedThroughHubSubQuery(query))
+        .orderBy('datetime', sort)
+        .range(Number(offset), Number(offset) + Number(limit) - 1);
+  
+      for await (let release of releases.results) {
+        release.type = 'release'
+        await release.format();
+      }
+  
+      const hubs = await Hub.query()
+        .where('handle', 'ilike', `%${query}%`)
+        .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+        .orderBy('datetime', sort)
+        .range(Number(offset), Number(offset) + Number(limit) - 1);
+      
+      for await (let hub of hubs.results) {
+        hub.type = 'hub'
+        await hub.format()
+      }
+  
+      const posts = await Post.query()
+        .where(ref('data:title').castText(), 'ilike', `%${query}%`)
+        .orWhere(ref('data:description').castText(), 'ilike', `%${query}%`)
+        .orWhereIn('hubId', getPublishedThroughHubSubQuery(query))
+        .orderBy('datetime', sort)
+        .range(Number(offset), Number(offset) + Number(limit) - 1);
+
+      for await (let post of posts.results) {
+        post.type = 'post'
+        await post.format();
+      }
+
+      ctx.body = {
+        accounts,
+        releases,
+        hubs,
+        posts,
+      };
+    } catch (error) {
+      console.log(error)
+      ctx.status = 400
+      ctx.body = {
+        message: 'Error fetching search results'
+      }
+    }
+});
 
   router.post('/search/v2', async (ctx) => {
     try { 

--- a/api/api.js
+++ b/api/api.js
@@ -2136,11 +2136,22 @@ export default (router) => {
         await post.format();
       }
 
+      const tags = await Tag.query()
+        .where('name', 'ilike', `%${query}%`)
+        .orderBy('name', sort)
+        .range(Number(offset), Number(offset) + Number(limit) - 1);
+      
+      for await (let tag of tags.results) {
+        tag.type = 'tag'
+        tag.format()
+      }
+
       ctx.body = {
         accounts,
         releases,
         hubs,
         posts,
+        tags,
       };
     } catch (error) {
       console.log(error)


### PR DESCRIPTION
endpoint for /search/all results

eventually we'll probably want to think about how to weight relevancy here probably using something like elastic search but for now this can be the basis of mobile search

closes #605 