### PR TITLE
fix get hubs w releases posts collaborators etc

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1330,9 +1330,9 @@ export default (router) => {
         }
       }
 
-      await hub.format();
       
-      if (hubOnly) {
+      if (hubOnly === 'true') {
+        await hub.format();
         ctx.body = {
           hub,
         }
@@ -1359,6 +1359,7 @@ export default (router) => {
       for await (let post of posts) {
         await post.format();
       }
+      await hub.format();
 
       ctx.body = {
         hub,


### PR DESCRIPTION
tiny little bug - calling `hub.format()` at the top stripped off of the knex functionality causes empty arrays for releases, posts, collaborators if `hubOnly=false` 