### PR TITLE
fix incorrectly named variable

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1491,7 +1491,7 @@ export default (router) => {
           .query()
           .joinRelated('hubs')
           .where('hubs_join.hubId', hub.id)
-          .where('hidden', false)
+          .where('archived', false)
           .orderByRaw('random()')
           .limit(limit)
 


### PR DESCRIPTION
variable had old hidden name - changed to 'archived'
![Screenshot 2024-08-28 at 11 27 06 AM](https://github.com/user-attachments/assets/3202c2eb-9643-499e-95df-dd121e19760c)
