### PR TITLE
change all processed commitments to confirmed

### DIFF
--- a/db/package.json
+++ b/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nina-protocol/nina-db",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "description": "",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/db/src/models/Release.js
+++ b/db/src/models/Release.js
@@ -55,7 +55,7 @@ export default class Release extends Model {
     }
 
     const connection = new anchor.web3.Connection(process.env.SOLANA_CLUSTER_URL);
-    const provider = new anchor.AnchorProvider(connection, {}, {commitment: 'processed'})  
+    const provider = new anchor.AnchorProvider(connection, {}, {commitment: 'confirmed'})  
     const program = await anchor.Program.at(
       process.env.NINA_PROGRAM_ID,
       provider,

--- a/indexer/processor.js
+++ b/indexer/processor.js
@@ -59,9 +59,9 @@ class NinaProcessor {
 
   async init() {
     const connection = new anchor.web3.Connection(process.env.SOLANA_CLUSTER_URL);
-    this.provider = new anchor.AnchorProvider(connection, {}, {commitment: 'processed'})  
+    this.provider = new anchor.AnchorProvider(connection, {}, {commitment: 'confirmed'})  
     const tokenIndexConnection = new anchor.web3.Connection(process.env.SOLANA_CLUSTER_URL);
-    this.tokenIndexProvider = new anchor.AnchorProvider(tokenIndexConnection, {commitment: 'processed'});
+    this.tokenIndexProvider = new anchor.AnchorProvider(tokenIndexConnection, {commitment: 'confirmed'});
     this.program = await anchor.Program.at(
       process.env.NINA_PROGRAM_ID,
       this.provider,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@bonfida/spl-name-service": "^0.1.51",
     "@koa/cors": "^3.3.0",
     "@metaplex-foundation/js": "^0.18.1",
-    "@nina-protocol/nina-db": "0.0.80",
+    "@nina-protocol/nina-db": "0.0.81",
     "@project-serum/anchor": "^0.25.0",
     "@redocly/cli": "^1.0.0-beta.108",
     "@solana/web3.js": "^1.73.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     bn.js "^5.2.0"
     debug "^4.3.4"
 
-"@nina-protocol/nina-db@0.0.80":
-  version "0.0.80"
-  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.80.tgz#7ab7d406f190eba164dc37a1e2dc5d80c0b360de"
-  integrity sha512-Tk5BmuQzG/T80bBIUNwNxpwgrnrl+aX3RiFh5Un8UlSudRWKZ/NX1gSyxx4WPzJDSyNaOpo8JaCzSGXnTYGB7w==
+"@nina-protocol/nina-db@0.0.81":
+  version "0.0.81"
+  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.81.tgz#1364a5815929e28c59e7a2a2591fa777ccf63c39"
+  integrity sha512-JtX+gD9GkkjJmJHiEkV58yXs1VB7UQGgez0p9vR7GWRR+Wde3MlGrpkIYTIaRHeIFK45p1V8ydiSfw/xUz3D1w==
   dependencies:
     "@babel/plugin-proposal-object-rest-spread" "^7.20.7"
     "@babel/preset-es2015" "^7.0.0-beta.53"


### PR DESCRIPTION
we have been having issues where releases created on the file service are unable to be found and processed offchain - this causes false negative errors to be reported like below

![Screenshot 2024-12-09 at 11 30 54 AM](https://github.com/user-attachments/assets/c7d056fa-19cf-46fe-8524-da5ed2f743e6)

In this case the release is created but we are unable to receive find it and return to the file service in the call to `/releases/:publicKeyOrSlug`

the file service only uses `confirmed` commitment - so the logic is here that using the same commitment to submit and lookup should result in elimination or reduction of false negatives