### PR TITLE
add retry to release find or create

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -1055,6 +1055,7 @@ export default (router) => {
           commitment: 'confirmed',
           maxSupportedTransactionVersion: 0
         })
+
         const restrictedReleases = await axios.get(`${process.env.ID_SERVER_ENDPOINT}/restricted`);
         const restrictedReleasesPublicKeys = restrictedReleases.data.restricted.map(x => x.value);
   

--- a/db/package.json
+++ b/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nina-protocol/nina-db",
-  "version": "0.0.81",
+  "version": "0.0.84",
   "description": "",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@bonfida/spl-name-service": "^0.1.51",
     "@koa/cors": "^3.3.0",
     "@metaplex-foundation/js": "^0.18.1",
-    "@nina-protocol/nina-db": "0.0.81",
+    "@nina-protocol/nina-db": "0.0.84",
     "@project-serum/anchor": "^0.25.0",
     "@redocly/cli": "^1.0.0-beta.108",
     "@solana/web3.js": "^1.73.2",
@@ -50,6 +50,7 @@
     "koa-ratelimit": "^5.0.1",
     "koa-router": "^12.0.0",
     "node-cron": "^3.0.2",
+    "promise-retry": "^2.0.1",
     "striptags": "^3.2.0",
     "web3": "^1.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,10 +1054,10 @@
     bn.js "^5.2.0"
     debug "^4.3.4"
 
-"@nina-protocol/nina-db@0.0.81":
-  version "0.0.81"
-  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.81.tgz#1364a5815929e28c59e7a2a2591fa777ccf63c39"
-  integrity sha512-JtX+gD9GkkjJmJHiEkV58yXs1VB7UQGgez0p9vR7GWRR+Wde3MlGrpkIYTIaRHeIFK45p1V8ydiSfw/xUz3D1w==
+"@nina-protocol/nina-db@0.0.84":
+  version "0.0.84"
+  resolved "https://registry.yarnpkg.com/@nina-protocol/nina-db/-/nina-db-0.0.84.tgz#f05d7087c79b23c184beb06689c62a23ef8e4213"
+  integrity sha512-WhZDAwkqrZUghVWcR3gMFhUcJr7VbmFXKJlnPAw1z4in0sbB9/LsthTFN6E91tEM/PWP+60HrCnmFSXfiR1rQw==
   dependencies:
     "@babel/plugin-proposal-object-rest-spread" "^7.20.7"
     "@babel/preset-es2015" "^7.0.0-beta.53"
@@ -2603,6 +2603,11 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 error-polyfill@^0.1.3:
   version "0.1.3"
@@ -4609,6 +4614,14 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
+
 prop-types@^15.5.0, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -4929,6 +4942,11 @@ retry@0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
 
 rimraf@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
here we add a promise retry to look up release when putting on chain - seems like this paired with the previous commitment changes (#772) should silence the false negatives - i think the fact that this wasnt being retried might actually be the thing that fixes it

in the below screenshot from false negative release create failure with https://www.ninaprotocol.com/releases/uk-shrill-hits-vol-1

the code here fixes the failure related to `nina-db/dist/models/Release.js:57`)

![Screenshot 2024-12-09 at 2 47 57 PM](https://github.com/user-attachments/assets/58345812-4d64-493a-b799-5f965c5ecc41)
