### PR TITLE
Add Claude Code review GitHub Action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,28 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude-code-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Action
+        uses: anthropics/claude-code-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Adds Claude Code review GitHub Action for automated PR reviews.

## Changes
- Added `.github/workflows/claude-code-review.yml`
- Configures Claude to automatically review PRs
- Responds to @claude mentions in PR comments
- Provides code suggestions and security analysis

## Setup Required
After merging, add the `ANTHROPIC_API_KEY` secret:
1. Go to https://github.com/nina-protocol/nina-indexer/settings/secrets/actions
2. Click "New repository secret"
3. Name: `ANTHROPIC_API_KEY`
4. Value: Your Anthropic API key
5. Click "Add secret"

## Features
- ✅ Automatic PR reviews when opened/updated
- ✅ Responds to @claude mentions
- ✅ Code suggestions and improvements
- ✅ Security-aware analysis