### PR TITLE
Fix Claude Code review workflow configuration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude-code-review:
@@ -23,6 +24,5 @@ jobs:
 
       - name: Claude Code Action
         uses: anthropics/claude-code-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
- Add id-token: write permission for OIDC token
- Pass ANTHROPIC_API_KEY via env instead of with inputs
- Remove invalid github-token and anthropic-api-key inputs