### PR TITLE
Remove redundant batch follower count query from hub followers endpoint

### DIFF
--- a/api/routes/HubRouter.js
+++ b/api/routes/HubRouter.js
@@ -175,25 +175,12 @@ router.get('/:publicKeyOrHandle/followers', async (ctx) => {
 
     const followers = []
     const accounts = await Account.query().whereIn('publicKey', subscriptions.results.map(subscription => subscription.from))
-    
-    // Batch fetch all follower counts to avoid N+1 queries
-    const accountPublicKeys = accounts.map(account => account.publicKey)
-    const followerCounts = await Subscription.query()
-      .whereIn('to', accountPublicKeys)
-      .select('to', Subscription.raw('count(*) as count'))
-      .groupBy('to')
-    
-    // Create a map for quick lookup
-    const followerCountMap = followerCounts.reduce((acc, row) => {
-      acc[row.to] = parseInt(row.count)
-      return acc
-    }, {})
-    
+
     for await (let account of accounts) {
       await account.format();
       followers.push({
         account,
-        followers: followerCountMap[account.publicKey] || 0,
+        followers: account.followers || 0,
         subscription: subscriptions.results.find(subscription => subscription.from === account.publicKey)
       })
     }


### PR DESCRIPTION
## Summary
- Removed raw batch SQL query (`SELECT "to", count(*) ... GROUP BY "to"`) from the `/hubs/:publicKeyOrHandle/followers` endpoint in HubRouter
- `account.format()` already fetches follower counts via the Redis-cached `getFollowCountForAccountWithCache`, so the batch query was redundant and hitting the DB at ~3.3 calls/sec unnecessarily
- Also includes prior commits adding `publisherAccount` to `Post.format()`

## Test plan
- [ ] Hit `/hubs/:publicKeyOrHandle/followers` and verify follower counts still populate correctly
- [ ] Confirm the batch `subscriptions` count query drops from DB performance insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)