### PR TITLE
Add timestamps to hubs_releases table

### DIFF
--- a/db/src/migrations/20260205000000_add_hubs_releases_timestamps.js
+++ b/db/src/migrations/20260205000000_add_hubs_releases_timestamps.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const up = function(knex) {
+  return knex.schema.table('hubs_releases', table => {
+    table.timestamp('created_at').defaultTo(knex.fn.now());
+    table.timestamp('updated_at').defaultTo(knex.fn.now());
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export const down = function(knex) {
+  return knex.schema.table('hubs_releases', table => {
+    table.dropColumn('created_at');
+    table.dropColumn('updated_at');
+  });
+};


### PR DESCRIPTION
## Summary
- Adds `created_at` and `updated_at` columns to the `hubs_releases` join table
- Uses `defaultTo(knex.fn.now())` so timestamps are set automatically at the DB level on insert — no application code changes needed
- Addresses nina-protocol/id-server#726

## Test plan
- [ ] Run migration against dev database
- [ ] Verify new `hubs_releases` rows get `created_at`/`updated_at` populated automatically
- [ ] Verify existing rows have `NULL` timestamps (no backfill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)