### PR TITLE
Move trending tags route to /stats/trending

### DIFF
--- a/api/routes/TagRouter.js
+++ b/api/routes/TagRouter.js
@@ -63,7 +63,7 @@ router.get('/', async (ctx) => {
   }
 })
 
-router.get('/trending', async (ctx) => {
+router.get('/stats/trending', async (ctx) => {
   try {
     const { window = '7d', limit = 20, override = 'false' } = ctx.query;
     const cacheKey = `tags:trending:batch:${window}:${limit}`;


### PR DESCRIPTION
## Summary
- Renames `GET /tags/trending` to `GET /tags/stats/trending` to avoid collision with `GET /tags/:value` (e.g. a tag literally named "trending")
- Cache key, logic, and response shape are unchanged

## Test plan
- [ ] `GET /v1/tags/stats/trending?window=7d&limit=12` returns trending tags batch response
- [ ] `GET /v1/tags/trending` no longer hits the batch endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)