### PR TITLE
Filter soft-deleted accounts and their content from public endpoints

### DIFF
--- a/api/routes/AccountRouter.js
+++ b/api/routes/AccountRouter.js
@@ -24,8 +24,11 @@ router.get('/', async(ctx) => {
     const { offset=0, limit=20, sort='desc', query= '' } = ctx.query;
     const accounts = await Account
       .query()
-      .where('handle', 'ilike', `%${query}%`)
-      .orWhere('displayName', 'ilike', `%${query}%`)
+      .whereNull('deleted_at')
+      .where((builder) => {
+        builder.where('handle', 'ilike', `%${query}%`)
+          .orWhere('displayName', 'ilike', `%${query}%`)
+      })
       .orderBy('displayName', sort)
       .range(Number(offset), Number(offset) + Number(limit) - 1);
       
@@ -52,7 +55,8 @@ router.get('/', async(ctx) => {
 router.get('/sitemap', async (ctx) => {
   try {
     const accounts = await Account
-      .query()  
+      .query()
+      .whereNull('deleted_at')
       .select('handle')
     ctx.body = {
       slugs: accounts.map(account => account.handle),
@@ -70,9 +74,9 @@ router.get('/:publicKeyOrHandle', async (ctx) => {
   try {
     const { v2, archived, full='false' } = ctx.query;
     const includeBlocks = full === 'true';
-    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle});
+    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
     if (!account) {
-      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle});
+      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
       if (!account) {
         accountNotFound(ctx);
         return;
@@ -148,9 +152,9 @@ router.get('/:publicKeyOrHandle/all', async (ctx) => {
     let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='', archived=false, full='false' } = ctx.query;
     const includeBlocks = full === 'true';
 
-    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle});
+    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
     if (!account) {
-      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle});
+      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
       if (!account) {
         accountNotFound(ctx);
         return;
@@ -215,9 +219,9 @@ router.get('/:publicKeyOrHandle/collected', async (ctx) => {
   try {
     let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='', showArchived=false } = ctx.query;
     column = formatColumnForJsonFields(column);
-    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle});
+    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
     if (!account) {
-      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle});
+      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
       if (!account) {
         accountNotFound(ctx);
         return;
@@ -276,9 +280,9 @@ router.get('/:publicKeyOrHandle/hubs', async (ctx) => {
   try {
     let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='' } = ctx.query;
     column = formatColumnForJsonFields(column, 'data');
-    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle});
+    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
     if (!account) {
-      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle});
+      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
       if (!account) {
         accountNotFound(ctx);
         return;
@@ -307,9 +311,9 @@ router.get('/:publicKeyOrHandle/posts', async (ctx) => {
     let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='', full='false' } = ctx.query;
     const includeBlocks = full === 'true';
     column = formatColumnForJsonFields(column, 'data');
-    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle});
+    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
     if (!account) {
-      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle});
+      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
       if (!account) {
         accountNotFound(ctx);
         return;
@@ -339,9 +343,9 @@ router.get('/:publicKeyOrHandle/published', async (ctx) => {
   try {
     let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', query='', showArchived=false } = ctx.query;
     column = formatColumnForJsonFields(column);
-    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle});
+    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
     if (!account) {
-      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle});
+      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
       if (!account) {
         accountNotFound(ctx);
         return;
@@ -519,9 +523,9 @@ router.get('/:publicKeyOrHandle/following', async (ctx) => {
 router.get('/:publicKeyOrHandle/following/newReleases', async (ctx) => {
   try {
     const { limit=50, offset=0 } = ctx.query;
-    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle});
+    let account = await Account.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
     if (!account) {
-      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle});
+      account = await Account.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNull('deleted_at');
       if (!account) {
         accountNotFound(ctx);
         return;
@@ -537,10 +541,10 @@ router.get('/:publicKeyOrHandle/following/newReleases', async (ctx) => {
     for await (let subscription of subscriptions) {
       if (subscription.subscriptionType === 'hub') {
         const hub = await Hub.query().findOne({ publicKey: subscription.to })
-        hubIds.push(hub.id)
+        if (hub) hubIds.push(hub.id)
       } else if (subscription.subscriptionType === 'account') {
-        const account = await Account.query().findOne({ publicKey: subscription.to })
-        accountIds.push(account.id)
+        const account = await Account.query().findOne({ publicKey: subscription.to }).whereNull('deleted_at')
+        if (account) accountIds.push(account.id)
       }
     }
     const notUserSubquery = Transaction.query()
@@ -548,7 +552,7 @@ router.get('/:publicKeyOrHandle/following/newReleases', async (ctx) => {
       .where('authorityId', account.id)
 
     const transactions = await Transaction.query()
-      .where((builder) => 
+      .where((builder) =>
         builder
           .whereIn('hubId', hubIds)
           .orWhereIn('toHubId', hubIds)
@@ -650,7 +654,11 @@ router.get('/:publicKeyOrHandle/verifications', async (ctx) => {
 router.get('/:publicKey/feed', async (ctx) => {
   try {
     const { limit=50, offset=0 } = ctx.query;
-    const account = await Account.findOrCreate(ctx.params.publicKey);
+    const account = await Account.query().findOne({ publicKey: ctx.params.publicKey }).whereNull('deleted_at');
+    if (!account) {
+      accountNotFound(ctx);
+      return;
+    }
     const subscriptions = await Subscription.query()
       .where('from', account.publicKey)
 
@@ -660,10 +668,10 @@ router.get('/:publicKey/feed', async (ctx) => {
     for await (let subscription of subscriptions) {
       if (subscription.subscriptionType === 'hub') {
         const hub = await Hub.query().findOne({ publicKey: subscription.to })
-        hubIds.push(hub.id)
+        if (hub) hubIds.push(hub.id)
       } else if (subscription.subscriptionType === 'account') {
-        const account = await Account.query().findOne({ publicKey: subscription.to })
-        accountIds.push(account.id)
+        const account = await Account.query().findOne({ publicKey: subscription.to }).whereNull('deleted_at')
+        if (account) accountIds.push(account.id)
       }
     }
     const notUserSubquery = Transaction.query()
@@ -671,7 +679,7 @@ router.get('/:publicKey/feed', async (ctx) => {
       .where('authorityId', account.id)
 
     const transactions = await Transaction.query()
-      .where((builder) => 
+      .where((builder) =>
         builder
           .whereIn('hubId', hubIds)
           .orWhereIn('toHubId', hubIds)

--- a/api/routes/HubRouter.js
+++ b/api/routes/HubRouter.js
@@ -10,7 +10,7 @@ import { ref } from 'objection'
 import * as anchor from '@project-serum/anchor';
 import axios from 'axios';
 
-import { formatColumnForJsonFields, BIG_LIMIT } from '../utils.js';
+import { formatColumnForJsonFields, getDeletedAccountIdsSubQuery, BIG_LIMIT } from '../utils.js';
 import { decode, callRpcMethodWithRetry } from '../../indexer/src/utils/index.js';
 import { warmCache } from '../../indexer/src/utils/helpers.js';
 import TransactionSyncer from '../../indexer/src/TransactionSyncer.js';
@@ -31,8 +31,11 @@ router.get('/', async (ctx) => {
     let { offset=0, limit=20, sort='desc', column='datetime', query='' } = ctx.query;
     column = formatColumnForJsonFields(column, 'data');
     const hubs = await Hub.query()
-      .where('handle', 'ilike', `%${query}%`)
-      .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+      .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
+      .where(function () {
+        this.where('handle', 'ilike', `%${query}%`)
+          .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+      })
       .orderBy(column, sort)
       .range(Number(offset), Number(offset) + Number(limit) - 1);
 
@@ -57,7 +60,8 @@ router.get('/', async (ctx) => {
 router.get('/sitemap', async (ctx) => {
   try {
     const hubs = await Hub
-      .query()  
+      .query()
+      .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
       .select('handle')
       .orderBy('datetime', 'desc')
     ctx.body = {
@@ -618,9 +622,9 @@ const lookupCollaborator = async (hubCollaboratorPublicKey) => {
 }
 
 const hubForPublicKeyOrHandle = async (ctx) => {
-  let hub = await Hub.query().findOne({publicKey: ctx.params.publicKeyOrHandle})
+  let hub = await Hub.query().findOne({publicKey: ctx.params.publicKeyOrHandle}).whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
   if (!hub) {
-    hub = await Hub.query().findOne({handle: ctx.params.publicKeyOrHandle})
+    hub = await Hub.query().findOne({handle: ctx.params.publicKeyOrHandle}).whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
   }
   return hub
 }

--- a/api/routes/HubRouter.js
+++ b/api/routes/HubRouter.js
@@ -137,7 +137,9 @@ router.get('/:publicKeyOrHandle', async (ctx) => {
       }
     }
 
-    let releases = await hub.$relatedQuery('releases').where('archived', false)
+    let releases = await hub.$relatedQuery('releases')
+      .where('archived', false)
+      .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
 
     if (hubOnly === 'true') {
       await hub.format();
@@ -274,6 +276,7 @@ router.get('/:publicKeyOrHandle/all', async (ctx) => {
       .where('hubs_join.visible', true)
       .where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
       .where('archived', false)
+      .whereNotIn('releases.publisherId', getDeletedAccountIdsSubQuery())
       .orderBy(column, sort)
       .range(Number(offset), Number(offset) + Number(limit) - 1);
 
@@ -324,6 +327,7 @@ router.get('/:publicKeyOrHandle/releases', async (ctx) => {
         .joinRelated("hubs")
         .where("hubs_join.hubId", hub.id)
         .where("hubs_join.visible", true)
+        .whereNotIn('releases.publisherId', getDeletedAccountIdsSubQuery())
         .orderByRaw("random()")
         .limit(limit);
 
@@ -338,6 +342,7 @@ router.get('/:publicKeyOrHandle/releases', async (ctx) => {
         .where("hubs_join.visible", true)
         .where(ref("metadata:name").castText(), "ilike", `%${query}%`)
         .where("archived", false)
+        .whereNotIn('releases.publisherId', getDeletedAccountIdsSubQuery())
         .orderBy(column, sort)
         .range(Number(offset), Number(offset) + Number(limit) - 1);
     }
@@ -377,6 +382,7 @@ router.get('/:publicKeyOrHandle/releases/archived', async (ctx) => {
       .where('hubs_join.hubId', hub.id)
       .where('hubs_join.visible', false)
       .where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
+      .whereNotIn('releases.publisherId', getDeletedAccountIdsSubQuery())
       .orderBy(column, sort)
       .range(Number(offset), Number(offset) + Number(limit) - 1);
 

--- a/api/routes/HubRouter.js
+++ b/api/routes/HubRouter.js
@@ -82,6 +82,23 @@ router.get('/:publicKeyOrHandle', async (ctx) => {
     const { hubOnly, full='false' } = ctx.query;
     const includeBlocks = full === 'true';
     if (!hub) {
+      // A hub whose authority is soft-deleted is filtered out by hubForPublicKeyOrHandle and lands here.
+      // Don't treat that as "not yet indexed" and re-fetch from chain — that would re-surface deleted content.
+      const deletedAuthorityHub = await Hub.query()
+        .where((builder) => {
+          builder.where('publicKey', ctx.params.publicKeyOrHandle)
+            .orWhere('handle', ctx.params.publicKeyOrHandle)
+        })
+        .whereIn('authorityId', getDeletedAccountIdsSubQuery())
+        .first()
+      if (deletedAuthorityHub) {
+        ctx.status = 404
+        ctx.body = {
+          message: `Hub not found with publicKey: ${ctx.params.publicKeyOrHandle}`
+        }
+        return
+      }
+
       const publicKey = ctx.params.publicKeyOrHandle
       const hubAccount = await callRpcMethodWithRetry(() => TransactionSyncer.program.account.hub.fetch(new anchor.web3.PublicKey(publicKey), 'confirmed'))
       if (hubAccount) {

--- a/api/routes/PostRouter.js
+++ b/api/routes/PostRouter.js
@@ -9,6 +9,7 @@ import * as anchor from '@project-serum/anchor';
 import {
   getPostSearchSubQuery,
   getPublishedThroughHubSubQuery,
+  getDeletedAccountIdsSubQuery,
 } from '../utils.js';
 import { callRpcMethodWithRetry } from '../../indexer/src/utils/index.js';
 
@@ -27,6 +28,7 @@ router.get('/', async (ctx) => {
     const posts = await Post
     .query()
     .where('archived', false)
+    .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     .withGraphFetched('releases')
     .where(function () {
       this.whereRaw(`data->>'title' ILIKE ?`, [`%${query}%`])
@@ -67,8 +69,9 @@ router.get('/', async (ctx) => {
 router.get('/sitemap', async (ctx) => {
   try {
     const posts = await Post
-      .query()  
+      .query()
       .where('archived', false)
+      .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
       .select(ref('data:slug').castText())
       .orderBy('datetime', 'desc')
     ctx.body = {
@@ -216,10 +219,12 @@ const postNotFound = (ctx) => {
 const findPostForPublicKeyOrSlug = async (publicKeyOrSlug) => {
   let post = await Post.query()
     .where('archived', false)
+    .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     .withGraphFetched('releases')
     .findOne({publicKey: publicKeyOrSlug})
   if (!post) {
     post = await Post.query()
+      .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
       .withGraphFetched('releases')
       .where(ref('data:slug').castText(), 'like', `%${publicKeyOrSlug}%`)
       .first()

--- a/api/routes/ReleaseRouter.js
+++ b/api/routes/ReleaseRouter.js
@@ -12,6 +12,7 @@ import {
   getReleaseSearchSubQuery,
   getPublisherSubQuery,
   getPublishedThroughHubSubQuery,
+  getDeletedAccountIdsSubQuery,
   BIG_LIMIT
 } from '../utils.js';
 import { warmCache } from '../../indexer/src/utils/helpers.js';
@@ -62,6 +63,7 @@ router.get('/', async (ctx) => {
       return Release.query()
         .where('archived', false)
         .whereNotIn('publisherId', idList)
+        .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
         .modify((queryBuilder) => {
           if (releaseIds.length > 0) {
             queryBuilder.whereIn('id', releaseIds);
@@ -122,6 +124,7 @@ router.get('/sitemap', async (ctx) => {
       .query()
       .where('archived', false)
       .whereNotIn('publicKey', restrictedReleasesPublicKeys)
+      .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
       .select('slug')
       .orderBy('datetime', 'desc')
     ctx.body = {
@@ -139,12 +142,12 @@ router.get('/sitemap', async (ctx) => {
 router.get('/:publicKeyOrSlug', async (ctx) => {
   try {
     const { txid } = ctx.query;
-    let release = await Release.query().findOne({publicKey: ctx.params.publicKeyOrSlug})
+    let release = await Release.query().findOne({publicKey: ctx.params.publicKeyOrSlug}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     if (!release) {
-      release = await Release.query().findOne({slug: ctx.params.publicKeyOrSlug})
+      release = await Release.query().findOne({slug: ctx.params.publicKeyOrSlug}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     }
     if (!release) {
-      release = await Release.query().findOne({solanaAddress: ctx.params.publicKeyOrSlug})
+      release = await Release.query().findOne({solanaAddress: ctx.params.publicKeyOrSlug}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     }
 
     if (txid) {
@@ -178,9 +181,9 @@ router.get('/:publicKeyOrSlug/posts', async (ctx) => {
     let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime', full='false' } = ctx.query;
     const includeBlocks = full === 'true';
     column = formatColumnForJsonFields(column);
-    let release = await Release.query().findOne({publicKey: ctx.params.publicKeyOrSlug})
+    let release = await Release.query().findOne({publicKey: ctx.params.publicKeyOrSlug}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     if (!release) {
-      release = await Release.query().findOne({slug: ctx.params.publicKeyOrSlug})
+      release = await Release.query().findOne({slug: ctx.params.publicKeyOrSlug}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     }
     if (!release) {
       throw new Error(`Release not found with identifier: ${ctx.params.publicKeyOrSlug}`)
@@ -210,10 +213,10 @@ router.get('/:publicKey/collectors', async (ctx) => {
   try {
     const { offset=0, limit=BIG_LIMIT } = ctx.query;
 
-    let release = await Release.query().findOne({publicKey: ctx.params.publicKey})
+    let release = await Release.query().findOne({publicKey: ctx.params.publicKey}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     if (!release) {
-      release = await Release.query().findOne({slug: ctx.params.publicKey})
-      
+      release = await Release.query().findOne({slug: ctx.params.publicKey}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
+
       if (!release) {
         throw new Error(`Release not found with identifier: ${ctx.params.publicKey}`)
       }
@@ -300,10 +303,10 @@ router.get('/:publicKey/hubs', async (ctx) => {
   try {
     let { offset=0, limit=BIG_LIMIT, sort='desc', column='datetime' } = ctx.query;
     column = formatColumnForJsonFields(column);
-    let release = await Release.query().findOne({publicKey: ctx.params.publicKey})
+    let release = await Release.query().findOne({publicKey: ctx.params.publicKey}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     if (!release) {
-      release = await Release.query().findOne({slug: ctx.params.publicKey})
-      
+      release = await Release.query().findOne({slug: ctx.params.publicKey}).whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
+
       if (!release) {
         throw new Error(`Release not found with identifier: ${ctx.params.publicKey}`)
       }

--- a/api/routes/SearchRouter.js
+++ b/api/routes/SearchRouter.js
@@ -10,7 +10,7 @@ import {
 import { ref } from 'objection'
 import _  from 'lodash';
 
-import { getReleaseSearchSubQuery, getPostSearchSubQuery, getPublishedThroughHubSubQuery, getPublisherSubQuery } from '../utils.js';
+import { getReleaseSearchSubQuery, getPostSearchSubQuery, getPublishedThroughHubSubQuery, getPublisherSubQuery, getDeletedAccountIdsSubQuery } from '../utils.js';
 
 const idList = [
   '13572',
@@ -43,6 +43,7 @@ router.get('/all', async (ctx) => {
 
     const [accountsPromise, releasesPromise, hubsPromise, tagsPromise] = await Promise.all([
       Account.query()
+        .whereNull('deleted_at')
         .whereIn('id', publisherIds)
         .orderBy('id', sort)
         .range(offset, offset + limit - 1),
@@ -56,6 +57,7 @@ router.get('/all', async (ctx) => {
         return Release.query()
           .where('archived', false)
           .whereNotIn('publisherId', blockedPublisherIds)
+          .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
           .modify((queryBuilder) => {
             if (releaseIds.length > 0) {
               queryBuilder.whereRaw('releases.id = ANY(?::int[])', [releaseIds]);
@@ -80,6 +82,7 @@ router.get('/all', async (ctx) => {
       })(),
 
       Hub.query()
+        .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
         .whereIn('id', hubIds)
         .orderBy('datetime', sort)
         .range(offset, offset + limit - 1),
@@ -152,6 +155,7 @@ router.get('/all', async (ctx) => {
       const postIds = await getPostSearchSubQuery(query);
       const postsQuery = await Post.query()
         .where('archived', false)
+        .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
         .modify((queryBuilder) => {
           if (postIds && postIds.length > 0) {
             queryBuilder.whereIn('id', postIds);
@@ -183,8 +187,11 @@ router.post('/v2', async (ctx) => {
     const includeBlocks = full === 'true';
     console.log('query', ctx.request.body)
     const accounts = await Account.query()
-      .where('displayName', 'ilike', `%${query}%`)
-      .orWhere('handle', 'ilike', `%${query}%`)
+      .whereNull('deleted_at')
+      .where(function () {
+        this.where('displayName', 'ilike', `%${query}%`)
+          .orWhere('handle', 'ilike', `%${query}%`)
+      })
     
     for await (let account of accounts) {
       account.type = 'account'
@@ -195,6 +202,7 @@ router.post('/v2', async (ctx) => {
     const releases = await Release.query()
       .where('archived', false)
       .whereNotIn('publisherId', idList)
+      .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
       .modify((queryBuilder) => {
         if (releaseIds && releaseIds.length > 0) {
           queryBuilder.whereIn('id', releaseIds);
@@ -209,18 +217,22 @@ router.post('/v2', async (ctx) => {
     }
     
     const hubs = await Hub.query()
-      .where('handle', 'ilike', `%${query}%`)
-      .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
-    
+      .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
+      .where(function () {
+        this.where('handle', 'ilike', `%${query}%`)
+          .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+      })
+
     for await (let hub of hubs) {
       hub.type = 'hub'
       await hub.format()
     }
-    
+
     const hubIds = await getPublishedThroughHubSubQuery(query);
     const postIds = await getPostSearchSubQuery(query);
     const posts = await Post.query()
     .where('archived', false)
+    .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
     .where(function () {
       this.whereRaw(`data->>'title' ILIKE ?`, [`%${query}%`])
         .orWhereRaw(`data->>'description' ILIKE ?`, [`%${query}%`])
@@ -270,11 +282,14 @@ router.post('/', async (ctx) => {
     }
 
     const releases = await Release.query()
-      .where(ref('metadata:description').castText(), 'ilike', `%${query}%`)
-      .orWhere(ref('metadata:properties.artist').castText(), 'ilike', `%${query}%`)
-      .orWhere(ref('metadata:properties.title').castText(), 'ilike', `%${query}%`)
-      .orWhere(ref('metadata:symbol').castText(), 'ilike', `%${query}%`)
-      .orWhereIn('hubId', getPublishedThroughHubSubQuery(query))
+      .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
+      .where(function () {
+        this.where(ref('metadata:description').castText(), 'ilike', `%${query}%`)
+          .orWhere(ref('metadata:properties.artist').castText(), 'ilike', `%${query}%`)
+          .orWhere(ref('metadata:properties.title').castText(), 'ilike', `%${query}%`)
+          .orWhere(ref('metadata:symbol').castText(), 'ilike', `%${query}%`)
+          .orWhereIn('hubId', getPublishedThroughHubSubQuery(query))
+      })
 
     const formattedReleasesResponse = []
     for await (let release of releases) {
@@ -310,9 +325,12 @@ router.post('/', async (ctx) => {
     }
 
     const hubs = await Hub.query()
-      .where('handle', 'ilike', `%${query}%`)
-      .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
-      .orWhere(ref('data:description').castText(), 'ilike', `%${query}%`)
+      .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
+      .where(function () {
+        this.where('handle', 'ilike', `%${query}%`)
+          .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+          .orWhere(ref('data:description').castText(), 'ilike', `%${query}%`)
+      })
     
     const formattedHubsResponse = []
     for await (let hub of hubs) {

--- a/api/routes/TagRouter.js
+++ b/api/routes/TagRouter.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import axios from 'axios';
 import knex from 'knex'
 import knexConfig from '../../db/src/knexfile.js'
+import { getDeletedAccountIdsSubQuery } from '../utils.js';
 
 const router = new KoaRouter({
   prefix: '/tags'
@@ -93,7 +94,7 @@ router.get('/stats/trending', async (ctx) => {
         if (!tag) continue;
 
         // Get non-archived releases for this tag
-        const allReleases = await Tag.relatedQuery('releases').for(tag.id).where('releases.archived', false);
+        const allReleases = await Tag.relatedQuery('releases').for(tag.id).where('releases.archived', false).whereNotIn('releases.publisherId', getDeletedAccountIdsSubQuery());
         if (allReleases.length === 0) continue;
 
         // Get weekly favorite counts
@@ -160,12 +161,12 @@ router.get('/:value', async (ctx) => {
     }
 
     // Get all releases for the tag
-    let releasesQuery = Tag.relatedQuery('releases').for(tag.id).where('releases.archived', false);
+    let releasesQuery = Tag.relatedQuery('releases').for(tag.id).where('releases.archived', false).whereNotIn('releases.publisherId', getDeletedAccountIdsSubQuery());
     let allReleases = await releasesQuery;
     const totalReleases = allReleases.length;
 
     // Get all posts for the tag
-    let postsQuery = Tag.relatedQuery('posts').for(tag.id).where('posts.archived', false);
+    let postsQuery = Tag.relatedQuery('posts').for(tag.id).where('posts.archived', false).whereNotIn('posts.publisherId', getDeletedAccountIdsSubQuery());
     let allPosts = await postsQuery;
     const totalPosts = allPosts.length;
 

--- a/api/utils.js
+++ b/api/utils.js
@@ -19,8 +19,11 @@ export const getPublishedThroughHubSubQuery = async (query) => {
   try {
     const hubs = await Hub.query()
     .select('id')
-    .where(ref('data:displayName').castText(), 'ilike', `%${query}%`)
-    .orWhere('handle', 'ilike', `%${query}%`);
+    .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
+    .where(function () {
+      this.where(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+        .orWhere('handle', 'ilike', `%${query}%`)
+    });
 
     // Ensure we're returning an array of numbers
     const hubIds = hubs.map(hub => {
@@ -40,8 +43,11 @@ export const getReleaseSearchSubQuery = async (query) => {
     // Get release IDs based only on text content
       const releases = await Release.query()
         .select('id', 'metadata')
-        .where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
-        .orWhere(ref('metadata:properties.tags').castText(), 'ilike', `%${query}%`)
+        .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
+        .where(function () {
+          this.where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
+            .orWhere(ref('metadata:properties.tags').castText(), 'ilike', `%${query}%`)
+        })
 
       return releases.map(row => row.id);
   } catch (error) {
@@ -54,9 +60,12 @@ export const getPostSearchSubQuery = async (query) => {
   try {
     const posts = await Post.query()
       .select('id', 'data')
-      .where(ref('data:title').castText(), 'ilike', `%${query}%`)
-      .orWhere(ref('data:description').castText(), 'ilike', `%${query}%`)
-      .orWhere(ref('data:tags').castText(), 'ilike', `%${query}%`)
+      .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
+      .where(function () {
+        this.where(ref('data:title').castText(), 'ilike', `%${query}%`)
+          .orWhere(ref('data:description').castText(), 'ilike', `%${query}%`)
+          .orWhere(ref('data:tags').castText(), 'ilike', `%${query}%`)
+      })
 
     return posts.map(row => row.id);
   } catch (error) {
@@ -69,8 +78,11 @@ export const getPublisherSubQuery = async (query) => {
   try {
     const publishers = await Account.query()
     .select('id')
-    .where('displayName', 'ilike', `%${query}%`)
-    .orWhere('handle', 'ilike', `%${query}%`);
+    .whereNull('deleted_at')
+    .where(function () {
+      this.where('displayName', 'ilike', `%${query}%`)
+        .orWhere('handle', 'ilike', `%${query}%`)
+    });
 
     // Ensure we're returning an array of numbers
     const publisherIds = publishers.map(publisher => {
@@ -89,6 +101,9 @@ export const getPublisherSubQuery = async (query) => {
     return [];
   }
 }
+
+export const getDeletedAccountIdsSubQuery = () =>
+  Account.query().select('id').whereNotNull('deleted_at');
 
 export const sleep = (time) => new Promise(resolve => setTimeout(resolve, time))
 

--- a/db/migrations/20260511000000_add_deleted_at_to_accounts.js
+++ b/db/migrations/20260511000000_add_deleted_at_to_accounts.js
@@ -1,0 +1,9 @@
+exports.up = (knex) =>
+  knex.schema.alterTable('accounts', (table) => {
+    table.timestamp('deleted_at').nullable();
+  });
+
+exports.down = (knex) =>
+  knex.schema.alterTable('accounts', (table) => {
+    table.dropColumn('deleted_at');
+  });

--- a/db/src/knexfile.js
+++ b/db/src/knexfile.js
@@ -18,7 +18,10 @@ export default {
       password: process.env.POSTGRES_PASSWORD,
     },
     migrations: {
-      directory: './node_modules/@nina-protocol/nina-db/dist/migrations',
+      directory: [
+        './node_modules/@nina-protocol/nina-db/dist/migrations',
+        join(__dirname, '../migrations'),
+      ],
     },
     auth: {
       client: 'postgresql',
@@ -39,7 +42,10 @@ export default {
       password: process.env.POSTGRES_PASSWORD,
     },
     migrations: {
-      directory: './node_modules/@nina-protocol/nina-db/dist/migrations',
+      directory: [
+        './node_modules/@nina-protocol/nina-db/dist/migrations',
+        join(__dirname, '../migrations'),
+      ],
     },
     auth: {
       client: 'postgresql',
@@ -60,7 +66,10 @@ export default {
       password: process.env.POSTGRES_PASSWORD,
     },
     migrations: {
-      directory: './node_modules/@nina-protocol/nina-db/dist/migrations',
+      directory: [
+        './node_modules/@nina-protocol/nina-db/dist/migrations',
+        join(__dirname, '../migrations'),
+      ],
     },
     auth: {
       client: 'postgresql',

--- a/db/src/models/Account.js
+++ b/db/src/models/Account.js
@@ -20,6 +20,7 @@ export default class Account extends Model {
       description: { type: 'string' },
       displayName: { type: 'string' },
       handle: { type: 'string' },
+      deleted_at: { type: ['string', 'null'] },
     },
   }
 


### PR DESCRIPTION
Add deleted_at column to accounts table via local migration. Filter deleted accounts from listings, search, sitemaps, direct lookups, and feeds. Releases/posts filtered by publisherId, hubs by authorityId.