### PR TITLE
Fix soft-delete search: use whereRaw for JSON fields instead of ref()

### DIFF
--- a/api/routes/HubRouter.js
+++ b/api/routes/HubRouter.js
@@ -34,7 +34,7 @@ router.get('/', async (ctx) => {
       .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
       .where(function () {
         this.where('handle', 'ilike', `%${query}%`)
-          .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+          .orWhereRaw(`data->>'displayName' ILIKE ?`, [`%${query}%`])
       })
       .orderBy(column, sort)
       .range(Number(offset), Number(offset) + Number(limit) - 1);

--- a/api/routes/SearchRouter.js
+++ b/api/routes/SearchRouter.js
@@ -7,7 +7,6 @@ import {
   Tag,
   Verification,
 } from '@nina-protocol/nina-db';
-import { ref } from 'objection'
 import _  from 'lodash';
 
 import { getReleaseSearchSubQuery, getPostSearchSubQuery, getPublishedThroughHubSubQuery, getPublisherSubQuery, getDeletedAccountIdsSubQuery } from '../utils.js';
@@ -220,7 +219,7 @@ router.post('/v2', async (ctx) => {
       .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
       .where(function () {
         this.where('handle', 'ilike', `%${query}%`)
-          .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+          .orWhereRaw(`data->>'displayName' ILIKE ?`, [`%${query}%`])
       })
 
     for await (let hub of hubs) {
@@ -284,10 +283,10 @@ router.post('/', async (ctx) => {
     const releases = await Release.query()
       .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
       .where(function () {
-        this.where(ref('metadata:description').castText(), 'ilike', `%${query}%`)
-          .orWhere(ref('metadata:properties.artist').castText(), 'ilike', `%${query}%`)
-          .orWhere(ref('metadata:properties.title').castText(), 'ilike', `%${query}%`)
-          .orWhere(ref('metadata:symbol').castText(), 'ilike', `%${query}%`)
+        this.whereRaw(`metadata->>'description' ILIKE ?`, [`%${query}%`])
+          .orWhereRaw(`metadata#>>'{properties,artist}' ILIKE ?`, [`%${query}%`])
+          .orWhereRaw(`metadata#>>'{properties,title}' ILIKE ?`, [`%${query}%`])
+          .orWhereRaw(`metadata->>'symbol' ILIKE ?`, [`%${query}%`])
           .orWhereIn('hubId', getPublishedThroughHubSubQuery(query))
       })
 
@@ -328,8 +327,8 @@ router.post('/', async (ctx) => {
       .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
       .where(function () {
         this.where('handle', 'ilike', `%${query}%`)
-          .orWhere(ref('data:displayName').castText(), 'ilike', `%${query}%`)
-          .orWhere(ref('data:description').castText(), 'ilike', `%${query}%`)
+          .orWhereRaw(`data->>'displayName' ILIKE ?`, [`%${query}%`])
+          .orWhereRaw(`data->>'description' ILIKE ?`, [`%${query}%`])
       })
     
     const formattedHubsResponse = []

--- a/api/utils.js
+++ b/api/utils.js
@@ -21,7 +21,7 @@ export const getPublishedThroughHubSubQuery = async (query) => {
     .select('id')
     .whereNotIn('authorityId', getDeletedAccountIdsSubQuery())
     .where(function () {
-      this.where(ref('data:displayName').castText(), 'ilike', `%${query}%`)
+      this.whereRaw(`data->>'displayName' ILIKE ?`, [`%${query}%`])
         .orWhere('handle', 'ilike', `%${query}%`)
     });
 
@@ -45,8 +45,8 @@ export const getReleaseSearchSubQuery = async (query) => {
         .select('id', 'metadata')
         .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
         .where(function () {
-          this.where(ref('metadata:name').castText(), 'ilike', `%${query}%`)
-            .orWhere(ref('metadata:properties.tags').castText(), 'ilike', `%${query}%`)
+          this.whereRaw(`metadata->>'name' ILIKE ?`, [`%${query}%`])
+            .orWhereRaw(`metadata#>>'{properties,tags}' ILIKE ?`, [`%${query}%`])
         })
 
       return releases.map(row => row.id);
@@ -62,9 +62,9 @@ export const getPostSearchSubQuery = async (query) => {
       .select('id', 'data')
       .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
       .where(function () {
-        this.where(ref('data:title').castText(), 'ilike', `%${query}%`)
-          .orWhere(ref('data:description').castText(), 'ilike', `%${query}%`)
-          .orWhere(ref('data:tags').castText(), 'ilike', `%${query}%`)
+        this.whereRaw(`data->>'title' ILIKE ?`, [`%${query}%`])
+          .orWhereRaw(`data->>'description' ILIKE ?`, [`%${query}%`])
+          .orWhereRaw(`data->>'tags' ILIKE ?`, [`%${query}%`])
       })
 
     return posts.map(row => row.id);


### PR DESCRIPTION
The soft-delete filtering work wrapped JSON-field text searches in .where(function(){...}) groups. Inside those groups, objection's ref() isn't recognized (the indexer ships objection 3 while @nina-protocol/nina-db pins objection 2, so a v3 ReferenceBuilder fails the v2 instanceof check and its internals leak as fake columns -> Postgres "column _expr does not exist").

Convert the grouped ref() calls to whereRaw with Postgres JSON operators (data->>'field', metadata#>>'{a,b}'), matching the existing PostRouter convention. Deleted-account filters stay chained on the main query.