### PR TITLE
Avoid bind-param overflow on search id lists (use = ANY(int[]))

### DIFF
--- a/api/routes/PostRouter.js
+++ b/api/routes/PostRouter.js
@@ -34,7 +34,7 @@ router.get('/', async (ctx) => {
       this.whereRaw(`data->>'title' ILIKE ?`, [`%${query}%`])
         .orWhereRaw(`data->>'description' ILIKE ?`, [`%${query}%`])
         .orWhereIn('hubId', hubIds)
-        .orWhereIn('id', postIds);
+        .orWhereRaw('"id" = ANY(?::int[])', [postIds]);
     })
     .orderBy(column, sort)
     .range(

--- a/api/routes/ReleaseRouter.js
+++ b/api/routes/ReleaseRouter.js
@@ -66,20 +66,20 @@ router.get('/', async (ctx) => {
         .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
         .modify((queryBuilder) => {
           if (releaseIds.length > 0) {
-            queryBuilder.whereIn('id', releaseIds);
+            queryBuilder.whereRaw('"id" = ANY(?::int[])', [releaseIds]);
           }
           if (publisherIds.length > 0) {
             if (releaseIds.length > 0) {
-              queryBuilder.orWhereIn('publisherId', publisherIds);
+              queryBuilder.orWhereRaw('"publisherId" = ANY(?::int[])', [publisherIds]);
             } else {
-              queryBuilder.whereIn('publisherId', publisherIds);
+              queryBuilder.whereRaw('"publisherId" = ANY(?::int[])', [publisherIds]);
             }
           }
           if (hubIds.length > 0) {
             if (releaseIds.length > 0 || publisherIds.length > 0) {
-              queryBuilder.orWhereIn('hubId', hubIds);
+              queryBuilder.orWhereRaw('"hubId" = ANY(?::int[])', [hubIds]);
             } else {
-              queryBuilder.whereIn('hubId', hubIds);
+              queryBuilder.whereRaw('"hubId" = ANY(?::int[])', [hubIds]);
             }
           }
         });

--- a/api/routes/SearchRouter.js
+++ b/api/routes/SearchRouter.js
@@ -157,7 +157,7 @@ router.get('/all', async (ctx) => {
         .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
         .modify((queryBuilder) => {
           if (postIds && postIds.length > 0) {
-            queryBuilder.whereIn('id', postIds);
+            queryBuilder.whereRaw('"id" = ANY(?::int[])', [postIds]);
           }
           if (hubIds && hubIds.length > 0) {
             queryBuilder.orWhereIn('hubId', hubIds);
@@ -204,7 +204,7 @@ router.post('/v2', async (ctx) => {
       .whereNotIn('publisherId', getDeletedAccountIdsSubQuery())
       .modify((queryBuilder) => {
         if (releaseIds && releaseIds.length > 0) {
-          queryBuilder.whereIn('id', releaseIds);
+          queryBuilder.whereRaw('"id" = ANY(?::int[])', [releaseIds]);
         }
       });
     
@@ -236,7 +236,7 @@ router.post('/v2', async (ctx) => {
       this.whereRaw(`data->>'title' ILIKE ?`, [`%${query}%`])
         .orWhereRaw(`data->>'description' ILIKE ?`, [`%${query}%`])
         .orWhereIn('hubId', hubIds)
-        .orWhereIn('id', postIds);
+        .orWhereRaw('"id" = ANY(?::int[])', [postIds]);
     })
     .orderBy('datetime', 'desc')
     .range(Number(offset), Number(offset) + Number(limit) - 1);


### PR DESCRIPTION
Now that the JSON-field search subqueries return real results again, broad queries can match tens of thousands of releases/posts. Feeding those id arrays into whereIn('id', ids) spread them into one bind param each, blowing past Postgres's 65535-parameter limit ("Error in releases index").

Pass the arrays as a single int[] param via '"id" = ANY(?::int[])', matching the existing SearchRouter precedent. Covers the large-table id sites in ReleaseRouter, PostRouter, and SearchRouter; logic/grouping unchanged.